### PR TITLE
Add redirect from main site to Streams microsite

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,3 +22,10 @@ command = "bash build.sh -p"
 [dev]
   targetPort = 1313
   port = 1314
+
+[[redirects]]
+  from = "/docs/streams/*"
+  to = "https://amplifystreams-open-docs.netlify.app/docs/:splat"
+  status = 200
+  force = true
+  headers = {X-From = "Netlify"}


### PR DESCRIPTION
@alexearnshaw Section 'Connect your microsite to the Axway-Open-Docs ecosystem.' - Can you please have a look at this update? I've followed instructions https://jira.axway.com/browse/RDAPI-20288 and example https://github.com/Axway/axway-open-docs/blob/redirect_test/netlify.toml but I'm not sure if I got this right. Thanks.