### PR TITLE
Update Streams landing page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,8 +64,8 @@ id = "UA-56643615-3"
 
 [languages]
 [languages.en]
-title = "AMPLIFY Streams Documentation"
-description = "AMPLIFY Streams Documentation"
+title = "Axway Open Documentation"
+description = "Axway Open Documentation"
 languageName ="English"
 # Weight used for sorting.
 weight = 1

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseURL = "https://amplifystreams-open-docs.netlify.com/"
-title = "AMPLIFY Streams"
+title = "Axway-Open-Docs"
 
 enableRobotsTXT = true
 
@@ -114,8 +114,8 @@ footer_about_disable = true
 [params.ui.feedback]
 enable = true
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
-yes = 'Glad to hear it! Please <a href="https://github.com/Axway/amplifystreams-open-docs/issues/new">tell us how we can improve</a>.'
-no = 'Sorry to hear that. Please <a href="https://github.com/Axway/amplifystreams-open-docs/issues/new">tell us how we can improve</a>.'
+yes = 'Glad to hear it! Please <a href="https://github.com/Axway/axway-open-docs/issues/new">tell us how we can improve</a>.'
+no = 'Sorry to hear that. Please <a href="https://github.com/Axway/axway-open-docs/issues/new">tell us how we can improve</a>.'
 
 # Adds a reading time to the top of each doc.
 # If you want this feature, but occasionally need to remove the Reading time from a single page, 
@@ -143,9 +143,9 @@ enable = true
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
 	name = "GitHub"
-	url = "https://github.com/Axway/amplifystreams-open-docs"
+	url = "https://github.com/Axway/axway-open-docs"
 	icon = "fab fa-github"
-        desc = "Amplify Streams project on GitHub"
+        desc = "Axway-Open-Docs project on GitHub"
 [[params.links.developer]]
 	name = "Axway Developer Portal"
 	url = "https://developer.axway.com/"

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -12,7 +12,7 @@ linkTitle = "Axway-Open-Docs"
 	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/Axway/amplifystreams-open-docs">
 		Repository <i class="fab fa-github ml-2 "></i>
 	</a>
-	<p class="lead mt-5">You can now contribute to the AMPLIFY Streams documentation directly!</p>
+	<p class="lead mt-5">You can now contribute to the documentation directly!</p>
 	<div class="mx-auto mt-5">
 		{{< blocks/link-down color="info" >}}
 	</div>

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Welcome to AMPLIFY Streams Documentation"
+title: "Welcome to AMPLIFY Streams documentation"
 linkTitle: "Documentation"
 weight: 20
 no_list: true
@@ -8,6 +8,21 @@ menu:
     weight: 20
 ---
 
+Axway AMPLIFY Streams documentation is available for collaboration using an open source model as part of the Axway Open Documentation Open Beta program.
+
+## About the Open Beta program
+
+The Open Beta enables you to suggest edits and create issues for any page of the documentation using a GitHub account. To learn more, see the [contribution guidelines](/docs/contribution_guidelines/).
+
+The role of each documentation website in the Open Beta is as follows:
+
+* Axway Open Documentation on Netlify (<https://axway-open-docs.netlify.app/>) - Specific product documentation sets are available on this website for contribution using GitHub and Netlify CMS.
+* Axway Documentation Portal (<https://docs.axway.com/>) - All Axway documentation is available on this website in read-only format.
+
+All contributions are first published on Axway Open Documentation, and shortly after on the Axway Documentation Portal, so that the latest documentation is always available on both websites.
+
 ## AMPLIFY Streams documentation
+
+This website contains the documentation set for AMPLIFY Streams.
 
 Browse all documentation for AMPLIFY Streams under the top-level [AMPLIFY Streams](/docs/streams/) item in the left navigation menu.


### PR DESCRIPTION
* Update text of landing pate (Welcome to AMPLIFY Streams documentation) to add paragraph about the Open Beta.
* Update some of the labels on the the default site config file back to Axway-open-docs, for instances in which should seem to a user like they are still on main open docs site. The `Language configuration` section is where the text of main header (to left corner) is set up.